### PR TITLE
Remove duplicate entries from base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ LABEL maintainer="LSIT Systems <lsitops@ucsb.edu>"
 
 USER root
 
-RUN R -e "install.packages(c('knitr', 'reshape2', 'datasets', 'MASS', 'arm', 'readstata13', 'readxl'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
+RUN R -e "install.packages(c('arm', 'readstata13'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 
 USER $NB_USER
 


### PR DESCRIPTION
I had installed packages that are already installed in the base image, this just cleans it up. 